### PR TITLE
forcibly consume last result

### DIFF
--- a/tarantool-driver/src/main/java/com/sopovs/moradanen/tarantool/TarantoolClient.java
+++ b/tarantool-driver/src/main/java/com/sopovs/moradanen/tarantool/TarantoolClient.java
@@ -8,6 +8,8 @@ public interface TarantoolClient extends Closeable {
 
     Result execute();
 
+    void consumeLastResult();
+
     void addBatch();
 
     void executeBatch();

--- a/tarantool-driver/src/main/java/com/sopovs/moradanen/tarantool/TarantoolClientImpl.java
+++ b/tarantool-driver/src/main/java/com/sopovs/moradanen/tarantool/TarantoolClientImpl.java
@@ -144,7 +144,7 @@ public class TarantoolClientImpl implements TarantoolClient {
                     throw new TarantoolException("Unknown body Key " + bodyKey);
                 }
             } else if (bodySize == 2) {
-                return new SqlResult(unpacker);
+                return last = new SqlResult(unpacker);
             } else {
                 throw new TarantoolException("Body size is " + bodySize);
             }
@@ -160,6 +160,14 @@ public class TarantoolClientImpl implements TarantoolClient {
         }
         finishQueryWithArguments();
         return getSingleResult();
+    }
+
+    @Override
+    public void consumeLastResult() {
+        if (last == null)
+            return;
+
+        while (last.next()) {}
     }
 
     @Override

--- a/tarantool-driver/src/main/java/com/sopovs/moradanen/tarantool/TarantoolPooledClientSource.java
+++ b/tarantool-driver/src/main/java/com/sopovs/moradanen/tarantool/TarantoolPooledClientSource.java
@@ -111,6 +111,11 @@ public class TarantoolPooledClientSource implements TarantoolClientSource {
                 if (poolClosed) {
                     client.close();
                 } else {
+                    /*
+                     * if execute some query and don`t process result we need forcibly consume last result.
+                     * If we don't, client will throw  an exception "Sending next without reading previous in next call"
+                     */
+                    consumeLastResult();
                     pool.add(client);
                     pool.notify();
                 }
@@ -144,6 +149,11 @@ public class TarantoolPooledClientSource implements TarantoolClientSource {
             } catch (TarantoolException e) {
                 throw closeOnException(e);
             }
+        }
+
+        @Override
+        public void consumeLastResult() {
+            client.consumeLastResult();
         }
 
         @Override

--- a/tarantool-driver/src/test/java/com/sopovs/moradanen/tarantool/TarantoolPooledClientSourceTest.java
+++ b/tarantool-driver/src/test/java/com/sopovs/moradanen/tarantool/TarantoolPooledClientSourceTest.java
@@ -210,6 +210,11 @@ class TarantoolPooledClientSourceTest {
         }
 
         @Override
+        public void consumeLastResult() {
+
+        }
+
+        @Override
         public void addBatch() {
             throw new TarantoolException("Not implemented!");
         }


### PR DESCRIPTION
if execute some query and don`t process result we need forcibly consume last result.
If we don't, client will throw  an exception "Sending next without reading previous in next call"